### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 docopt==0.6.2
-more_itertools==8.4.0
 robobro==0.5.3
-beautifulsoup4==4.9.1
-robobrowser==0.5.3


### PR DESCRIPTION
- robobro is the fixed robobrowser package,
  installing both lead to problems with import from werkzeuge
- removed more_itertools since it is not used anymore
- removed beautifulsoup4, comes along with robobro