### PR TITLE
Add handling for "Abgesagt" match date

### DIFF
--- a/helper/match.py
+++ b/helper/match.py
@@ -48,6 +48,8 @@ class Match(object):
                 self.__match_date = datetime.strptime(date, '%d.%m.%y %H:%M')
             except Exception:
                 self.__match_date = None
+                if date == "Abgesagt":
+                    self.__match_date = "Abgesagt"
         elif type(date) is datetime:
             self.__match_date = date
         else:

--- a/kicktippbb.py
+++ b/kicktippbb.py
@@ -115,6 +115,8 @@ def parse_match_rows(browser: RoboBrowser, community, matchday = None):
         except:
             print("Error: Not enough data, maybe there are no rates yet.")
             sys.exit()
+        if match.match_date == "Abgesagt":
+            continue
         if not match.match_date:
             match.match_date = lastmatch.match_date
         lastmatch = match


### PR DESCRIPTION
The script simply aborted if a match has no match date attribute on kicktipp.  This happens whenever a match becomes aborted.
Then there is the text "Abgesagt" inside the date column.

I added a check to skip aborted matches.